### PR TITLE
docs: config github codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Team-Drinki/drinki-backend


### PR DESCRIPTION
CODEOWNERS 파일을 작성하면 PR reviewer를 자동으로 지정할 수 있다고 합니다.
[공식 문서](https://docs.github.com/ko/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)